### PR TITLE
fix: prevent daily production from dropping to 0

### DIFF
--- a/.changeset/nasty-rocks-rush.md
+++ b/.changeset/nasty-rocks-rush.md
@@ -1,0 +1,5 @@
+---
+"nep_api": patch
+---
+
+fix dips to 0

--- a/src/nepapifetcher.ts
+++ b/src/nepapifetcher.ts
@@ -51,6 +51,9 @@ export type statisticsProduction = {
   totalMoneyUnit: string;
 };
 
+let lastTodayProduction = 0;
+let lastProductionUpdateDate: Date | null = null;
+
 export async function getSiteData(
   sid: string,
   jwt: string,
@@ -84,5 +87,26 @@ export async function getSiteData(
   });
 
   const data = await res.json();
-  return data.data.statisticsProduction;
+  const productionData = data.data.statisticsProduction;
+  const currentDate = new Date();
+
+  const isNewDay =
+    lastProductionUpdateDate === null ||
+    currentDate.getDate() !== lastProductionUpdateDate.getDate() ||
+    currentDate.getMonth() !== lastProductionUpdateDate.getMonth() ||
+    currentDate.getFullYear() !== lastProductionUpdateDate.getFullYear();
+
+  if (isNewDay) {
+    lastTodayProduction = productionData.today;
+    lastProductionUpdateDate = currentDate;
+  } else {
+    if (productionData.today === 0 && lastTodayProduction !== 0) {
+      productionData.today = lastTodayProduction;
+    } else {
+      lastTodayProduction = productionData.today;
+      lastProductionUpdateDate = currentDate;
+    }
+  }
+
+  return productionData;
 }

--- a/test/nepapifetcher.test.ts
+++ b/test/nepapifetcher.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, mock, test } from "bun:test";
 import { getJwtToken, getSiteData } from "../src/nepapifetcher";
 
 test("Env variables present", () => {
@@ -16,4 +16,66 @@ test("API fetcher", async () => {
   const jwt = await getJwtToken(process.env.username, process.env.password);
   const siteData = await getSiteData(process.env.sid, jwt);
   expect(siteData).toBeDefined();
+});
+
+test("API fetcher with cache logic", async () => {
+  const originalFetch = global.fetch;
+  const mockFn = mock();
+  global.fetch = mockFn;
+
+  mockFn.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({
+        data: {
+          statisticsProduction: {
+            today: 10.5,
+            todayUnit: "kWh",
+            month: 50,
+            monthUnit: "kWh",
+            year: 600,
+            yearUnit: "kWh",
+            total: 1200,
+            totalUnit: "kWh",
+            totalNow: 1.5,
+            totalNowUnit: "kW",
+            totalMoney: 150,
+            totalMoneyUnit: "USD",
+          },
+        },
+      }),
+    ),
+  );
+  mockFn.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({
+        data: {
+          statisticsProduction: {
+            today: 0,
+            todayUnit: "kWh",
+            month: 50,
+            monthUnit: "kWh",
+            year: 600,
+            yearUnit: "kWh",
+            total: 1200,
+            totalUnit: "kWh",
+            totalNow: 1.5,
+            totalNowUnit: "kW",
+            totalMoney: 150,
+            totalMoneyUnit: "USD",
+          },
+        },
+      }),
+    ),
+  );
+
+  const jwt = "fake-jwt";
+  const sid = "fake-sid";
+
+  const data1 = await getSiteData(sid, jwt);
+  expect(data1.today).toBe(10.5);
+
+  const data2 = await getSiteData(sid, jwt);
+  expect(data2.today).toBe(10.5);
+
+  global.fetch = originalFetch; // cleanup
 });


### PR DESCRIPTION
The API from the micro inverter sometimes drops the value for the day's production to 0 and after a small time back to its correct value. This commit introduces a caching mechanism to prevent these intermittent zero values from being propagated. The last valid production value is cached and returned when a zero value is received. The cache is reset at midnight to ensure the daily production value is correctly reset to 0 at the start of a new day.